### PR TITLE
Let bors cut body after <details>

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,7 +3,7 @@ status = [
     "CI"
 ]
 
-cut_body_after = "---"
+cut_body_after = "<details>"
 
 delete_merged_branches = true
 


### PR DESCRIPTION
This was set to "---" because I thought it would make life easier for contributors to use the markdown line "---".

It turned out, though, that dependabot uses a `<details>` tag and puts a lot of HTML in there. We really don't want that in our merge messages.

So this patch changes bors configuration to cut the merge message after the `<details>` tag.
