### PR TITLE
one-liner changes to remove examples/*.rs compilation error

### DIFF
--- a/examples/bash.rs
+++ b/examples/bash.rs
@@ -1,5 +1,5 @@
 extern crate rexpect;
-use rexpect::error::Error;
+use rexpect::errors::Error;
 use rexpect::spawn_bash;
 
 fn main() -> Result<(), Error> {

--- a/examples/bash_read.rs
+++ b/examples/bash_read.rs
@@ -1,5 +1,5 @@
 extern crate rexpect;
-use rexpect::error::Error;
+use rexpect::errors::Error;
 use rexpect::spawn_bash;
 
 fn main() -> Result<(), Error> {

--- a/examples/exit_code.rs
+++ b/examples/exit_code.rs
@@ -1,6 +1,6 @@
 extern crate rexpect;
 
-use rexpect::error::Error;
+use rexpect::errors::Error;
 use rexpect::process::wait;
 use rexpect::spawn;
 

--- a/examples/ftp.rs
+++ b/examples/ftp.rs
@@ -1,6 +1,6 @@
 extern crate rexpect;
 
-use rexpect::error::Error;
+use rexpect::errors::Error;
 use rexpect::spawn;
 
 fn main() -> Result<(), Error> {

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -2,7 +2,7 @@
 
 extern crate rexpect;
 
-use rexpect::error::Error;
+use rexpect::errors::Error;
 use rexpect::session::PtyReplSession;
 use rexpect::spawn;
 

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -1,3 +1,4 @@
+extern crate rexpect;
 use rexpect::spawn_stream;
 use std::error::Error;
 use std::net::TcpStream;


### PR DESCRIPTION
Hi There
I went through all example/*.rs and found these small one-liner changes to  remove compilation  errors. Tested against rust 1.64.