### PR TITLE
tcp.rs missing extern crate rexpect; line

### DIFF
--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -1,3 +1,4 @@
+extern crate rexpect;
 use rexpect::spawn_stream;
 use std::error::Error;
 use std::net::TcpStream;


### PR DESCRIPTION
without this line like other .rs files in  examples dir all have, I can't compile in my rust 1.64 environment.