### PR TITLE
minor documentation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,14 @@ Add this to your `Cargo.toml`
 
 ```toml
 [dependencies]
-rexpect = "0.4"
+rexpect = "0.5"
 ```
 
 Simple example for interacting via ftp:
 
 ```rust
-extern crate rexpect;
-
 use rexpect::spawn;
-use rexpect::errors::*;
+use rexpect::error::*;
 
 fn do_ftp() -> Result<()> {
     let mut p = spawn("ftp speedtest.tele2.net", Some(30_000))?;
@@ -63,9 +61,8 @@ fn main() {
 ### Example with bash and reading from programs
 
 ```rust
-extern crate rexpect;
 use rexpect::spawn_bash;
-use rexpect::errors::*;
+use rexpect::error::*;
 
 fn do_bash() -> Result<()> {
     let mut p = spawn_bash(Some(2000))?;
@@ -114,9 +111,8 @@ goes into nirvana. There are two functions to ensure that:
 
 
 ```rust
-extern crate rexpect;
 use rexpect::spawn_bash;
-use rexpect::errors::*;
+use rexpect::error::*;
 
 fn do_bash_jobcontrol() -> Result<()> {
     let mut p = spawn_bash(Some(1000))?;
@@ -151,7 +147,6 @@ rust stable, beta and nightly on both Linux or Mac.
 
 ## Design decisions
 
-- use error handling of [error-chain](https://github.com/brson/error-chain)
 - use [nix](https://github.com/nix-rust/nix) (and avoid libc wherever possible)
   to keep the code safe and clean
 - sadly, `expect` is used in rust too prominently to unwrap `Option`s and

--- a/examples/bash.rs
+++ b/examples/bash.rs
@@ -1,4 +1,3 @@
-extern crate rexpect;
 use rexpect::error::Error;
 use rexpect::spawn_bash;
 

--- a/examples/bash_read.rs
+++ b/examples/bash_read.rs
@@ -1,4 +1,3 @@
-extern crate rexpect;
 use rexpect::error::Error;
 use rexpect::spawn_bash;
 

--- a/examples/exit_code.rs
+++ b/examples/exit_code.rs
@@ -1,5 +1,3 @@
-extern crate rexpect;
-
 use rexpect::error::Error;
 use rexpect::process::wait;
 use rexpect::spawn;

--- a/examples/ftp.rs
+++ b/examples/ftp.rs
@@ -1,5 +1,3 @@
-extern crate rexpect;
-
 use rexpect::error::Error;
 use rexpect::spawn;
 

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -1,7 +1,5 @@
 //! An example how you would test your own repl
 
-extern crate rexpect;
-
 use rexpect::error::Error;
 use rexpect::session::PtyReplSession;
 use rexpect::spawn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 //! # Basic example
 //!
 //! ```no_run
-//! extern crate rexpect;
 //!
 //! use rexpect::spawn;
 //! use rexpect::error::Error;
@@ -47,7 +46,6 @@
 //! printed "above" the last `execute()`.
 //!
 //! ```no_run
-//! extern crate rexpect;
 //! use rexpect::spawn_bash;
 //! use rexpect::error::Error;
 //!

--- a/src/process.rs
+++ b/src/process.rs
@@ -29,9 +29,6 @@ use std::{thread, time};
 /// # #![allow(unused_mut)]
 /// # #![allow(unused_variables)]
 ///
-/// extern crate nix;
-/// extern crate rexpect;
-///
 /// use rexpect::process::PtyProcess;
 /// use std::process::Command;
 /// use std::fs::File;
@@ -151,7 +148,6 @@ impl PtyProcess {
     /// # Example
     /// ```rust,no_run
     ///
-    /// # extern crate rexpect;
     /// use rexpect::process::{self, wait::WaitStatus};
     /// use std::process::Command;
     ///


### PR DESCRIPTION
Sets the version in README to 0.5 and removes the unneeded `export crate` from the docs and examples.

Signed-off-by: Petre Eftime <petre.eftime@gmail.com>