### PR TITLE
remove unneeded unwraps

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,5 @@ rust stable, beta and nightly on both Linux or Mac.
 
 - use [nix](https://github.com/nix-rust/nix) (and avoid libc wherever possible)
   to keep the code safe and clean
-- sadly, `expect` is used in rust too prominently to unwrap `Option`s and
-  `Result`s, use `exp_*` instead
 
 Licensed under [MIT License](LICENSE)

--- a/src/session.rs
+++ b/src/session.rs
@@ -192,7 +192,7 @@ impl DerefMut for PtySession {
 /// ```
 impl PtySession {
     fn new(process: PtyProcess, timeout_ms: Option<u64>) -> Result<Self, Error> {
-        let f = process.get_file_handle();
+        let f = process.get_file_handle()?;
         let reader = f.try_clone()?;
         let stream = StreamSession::new(reader, f, timeout_ms);
         Ok(Self { process, stream })
@@ -373,16 +373,14 @@ pub fn spawn_bash(timeout: Option<u64>) -> Result<PtyReplSession, Error> {
     // wait for the first prompt since we don't know what .bashrc
     // would set as PS1 and we cannot know when is the right time
     // to set the new PS1
-    let mut rcfile = tempfile::NamedTempFile::new().unwrap();
-    let _ = rcfile
-        .write(
-            b"include () { [[ -f \"$1\" ]] && source \"$1\"; }\n\
+    let mut rcfile = tempfile::NamedTempFile::new()?;
+    let _ = rcfile.write(
+        b"include () { [[ -f \"$1\" ]] && source \"$1\"; }\n\
                   include /etc/bash.bashrc\n\
                   include ~/.bashrc\n\
                   PS1=\"~~~~\"\n\
                   unset PROMPT_COMMAND\n",
-        )
-        .expect("cannot write to tmpfile");
+    )?;
     let mut c = Command::new("bash");
     c.args(&[
         "--rcfile",


### PR DESCRIPTION
Note, this slightly changes the pub API, so it should require a minor version bump at least.

There is still an `unwrap` in a `Drop` where it's unclear if it can happen or it can be handled better (maybe just ignored?) and an `expect` in a function where the expect should not happen (it's checked before), and I didn't consider that it's worth adding a new Error kind for this in particular.

Signed-off-by: Petre Eftime <petre.eftime@gmail.com>