### PR TITLE
fix typo in error message

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -342,7 +342,7 @@ impl Drop for PtyReplSession {
         if let Some(ref cmd) = self.quit_command {
             self.pty_session
                 .send_line(cmd)
-                .expect("could not run `exit` on bash process");
+                .expect(&format!("could not run `{}` on child process", cmd));
         }
     }
 }


### PR DESCRIPTION
The error message in PtyReplSessions Drop impl implies that the subprocess is "bash", which isn't necessarily true and might confuse users.