### PR TITLE
PtyProcess: add NO_CTTY flag

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -86,7 +86,7 @@ impl PtyProcess {
     /// Start a process in a forked pty
     pub fn new(mut command: Command) -> Result<Self, Error> {
         // Open a new PTY master
-        let master_fd = posix_openpt(OFlag::O_RDWR)?;
+        let master_fd = posix_openpt(OFlag::O_RDWR | OFlag::O_NOCTTY)?;
 
         // Allow a slave to be generated for it
         grantpt(&master_fd)?;


### PR DESCRIPTION
The default behavior of posix_openpt seems to be to replace the controlling terminal for the calling process, and PtyProcess should only change it for child instead. I think this might be a reason why some of the tests were failing non-deterministacally sometimes, although I am not 100% confident in this fix.

Signed-off-by: Petre Eftime <petre.eftime@gmail.com>