### PR TITLE
update to swatinem/rust-cache@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
       - name: cargo-check
         uses: actions-rs/cargo@v1
         with:
@@ -51,7 +51,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
       - name: cargo-test
         uses: actions-rs/cargo@v1
         with:
@@ -107,7 +107,7 @@ jobs:
         with:
           toolchain: 1.67.0
           components: clippy
-      - uses: swatinem/rust-cache@v1
+      - uses: swatinem/rust-cache@v2
       - name: cargo-clippy
         run: cargo clippy --all --all-targets --all-features
 


### PR DESCRIPTION
rust-cache@v1 seems to generate some deprecation warnings, so better update to v2.