### PR TITLE
Allow setting window size in spawned process.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.60"
 
 [dependencies]
 comma = "1.0"
-nix = { version = "0.27", features = ["fs", "process", "signal", "term"] }
+nix = { version = "0.27", features = ["fs", "process", "signal", "term", "ioctl"] }
 regex = "1"
 tempfile = "3"
 thiserror = "1.0.34"


### PR DESCRIPTION
My use-case for this is for testing a shell that uses the `rustyline` crate for line-editing.
For long inputs (greater than the terminal width), `rustyline` inserts newlines into its output, which breaks tests using `rexpect` to match expected strings.
This PR would allow users to for example, set the terminal size to 200 columns wide, avoiding the aforementioned problem.
The feature is available in `pexpect`.

Coincidentally, this PR addresses the newly opened #119.

## Draft Status
The PR is in draft because I am not sure what the best way to go about passing the `Options` is.
Currently it already feels weird to me propagating the `reader::Options` from `spawn_with_options` down the various containers to the `NBReader`.