### PR TITLE
Add try_read_byte method.

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -88,6 +88,10 @@ impl<W: Write> StreamSession<W> {
         self.reader.try_read()
     }
 
+    pub fn try_read_byte(&mut self) -> Option<u8> {
+        self.reader.try_read_byte()
+    }
+
     // wrapper around reader::read_until to give more context for errors
     fn exp(&mut self, needle: &ReadUntil) -> Result<(String, String), Error> {
         self.reader.read_until(needle)


### PR DESCRIPTION
Added try_read_byte method.
The try_read method may cause a panic when reading u8 as char with some colored characters . #103 
Add a method to get u8 characters directly