### PR TITLE
nix 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
@@ -133,9 +133,9 @@ checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "537bc3c4a347b87fd52ac6c03a02ab1302962cfd93373c5d7a112cdc337854cc"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ which = ["dep:which"]
 
 [dependencies]
 comma = "1.0"
-nix = { version = "0.29", features = ["fs", "process", "signal", "term"] }
+nix = { version = "0.30", features = ["fs", "process", "signal", "term"] }
 regex = "1"
 tempfile = "3"
 thiserror = "2.0.0"

--- a/src/process.rs
+++ b/src/process.rs
@@ -42,8 +42,8 @@ use std::{thread, time};
 /// # fn main() {
 ///
 /// let mut process = PtyProcess::new(Command::new("cat")).expect("could not execute cat");
-/// let fd = dup(process.pty.as_raw_fd()).unwrap();
-/// let f = unsafe { File::from_raw_fd(fd) };
+/// let fd = dup(&process.pty).unwrap();
+/// let f = File::from(fd);
 /// let mut writer = LineWriter::new(&f);
 /// let mut reader = BufReader::new(&f);
 /// process.exit().expect("could not terminate process");

--- a/src/process.rs
+++ b/src/process.rs
@@ -3,15 +3,17 @@
 use crate::error::Error;
 use nix;
 use nix::fcntl::{open, OFlag};
-use nix::libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
+use nix::libc::STDERR_FILENO;
 use nix::pty::{grantpt, posix_openpt, unlockpt, PtyMaster};
 pub use nix::sys::{signal, wait};
 use nix::sys::{stat, termios};
-use nix::unistd::{close, dup, dup2, fork, setsid, ForkResult, Pid};
+use nix::unistd::{
+    close, dup, dup2_stderr, dup2_stdin, dup2_stdout, fork, setsid, ForkResult, Pid,
+};
 use std;
 use std::fs::File;
 use std::io;
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 use std::{thread, time};
@@ -109,12 +111,12 @@ impl PtyProcess {
                 )?;
 
                 // assign stdin, stdout, stderr to the tty, just like a terminal does
-                dup2(slave_fd, STDIN_FILENO)?;
-                dup2(slave_fd, STDOUT_FILENO)?;
-                dup2(slave_fd, STDERR_FILENO)?;
+                dup2_stdin(&slave_fd)?;
+                dup2_stdout(&slave_fd)?;
+                dup2_stderr(&slave_fd)?;
 
                 // Avoid leaking slave fd
-                if slave_fd > STDERR_FILENO {
+                if slave_fd.as_raw_fd() > STDERR_FILENO {
                     close(slave_fd)?;
                 }
 
@@ -138,8 +140,8 @@ impl PtyProcess {
     /// Get handle to pty fork for reading/writing
     pub fn get_file_handle(&self) -> Result<File, Error> {
         // needed because otherwise fd is closed both by dropping process and reader/writer
-        let fd = dup(self.pty.as_raw_fd())?;
-        unsafe { Ok(File::from_raw_fd(fd)) }
+        let fd = dup(&self.pty)?;
+        Ok(fd.into())
     }
 
     /// At the drop of `PtyProcess` the running process is killed. This is blocking forever if


### PR DESCRIPTION
`dup`/`dup2` now encode their ownership semantics in the type system. Special variants of `dup2` were added for the I/O redirection which we use here. `dup` now takes an `Fd` instead of a `RawFd` and returns an `OwnedFd`, which is directly convertible to a `File`, so we can get rid of some conversion boilerplate in `get_file_handle`.