### PR TITLE
fix: ensure consistent bash command output across terminal environments

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -397,6 +397,7 @@ pub fn spawn_bash(timeout: Option<u64>) -> Result<PtyReplSession, Error> {
                   unset PROMPT_COMMAND\n",
     )?;
     let mut c = Command::new("bash");
+    c.env("TERM", "");
     c.args([
         "--rcfile",
         rcfile.path().to_str().unwrap_or("temp file does not exist"),


### PR DESCRIPTION
The output from `spawn_bash` was inconsistent depending on the terminal environment where the process was spawned. In tmux and other advanced terminals, the output included ANSI control sequences for features like bracketed paste mode, causing test failures and unreliable behavior.

Set TERM="" when spawning bash to force a dumb terminal mode, ensuring clean, consistent output regardless of the parent terminal environment.

Example error:

```
thread 'session::tests::test_bash' panicked at src/session.rs:542:9:
assertion `left == right` failed
  left: "/tmp\r\n"
  right: "\u{1b}[?2004l\r\r\n/tmp\r\n\u{1b}[?2004h"
 ```